### PR TITLE
Install bower on postinstall

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "url": "https://github.com/kmees/karma-sinon-chai/issues"
   },
   "scripts": {
-    "prepublish": "node ./node_modules/bower/bin/bower install"
+    "postinstall": "node ./node_modules/bower/bin/bower install"
   },
   "contributors": [
     "Greg Thornton <xdissent@me.com>",


### PR DESCRIPTION
when adding the git repo to package.json, currently the additional dependencies do not get installed, because they are only available within the packaged component. Changing from prepublish to postinstall should fix that problem.
