### PR TITLE
Update sinon and chai dependencies to latest versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,8 +25,8 @@
     "Tobias Kopelke <nox@raynode.de>"
   ],
   "dependencies": {
-    "chai": "~3.2.0",
-    "sinon": "~1.16.0",
+    "chai": "^3.4.1",
+    "sinon": "^1.17.2",
     "sinon-chai": "~2.8.0"
   },
   "devDependencies": {}


### PR DESCRIPTION
I stumbled onto this issue when using ```karma-sinon-chai``` with JSPM and latest ```core-js```. 
```
Chrome 46.0.2490 (Windows 10 0.0.0) ERROR: 'Potentially unhandled rejection [3] Uncaught Uncaught Uncaught Uncaught TypeError: undefined is not a function!
        Evaluating http://localhost:9876/base/jspm_packages/npm/core-js@1.2.6/modules/web.immediate.js
        Evaluating http://localhost:9876/base/jspm_packages/npm/core-js@1.2.6/shim.js
        Evaluating http://localhost:9876/base/jspm_packages/npm/core-js@1.2.6/index.js
        Evaluating http://localhost:9876/base/jspm_packages/npm/core-js@1.2.6.js
        Error loading http://localhost:9876/base/src/app.js (WARNING: non-Error used)'
```
Not quite sure what the actual issue is. But increasing the referenced ```sinon``` and ```chai``` dependencies in ```karma-sinon-chai``` helped.