### PR TITLE
fix #32 and #33 upgrade lolex and move it to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,10 +26,11 @@
   ],
   "peerDependencies": {
     "chai": "^3.2.0",
-    "lolex": "^1.4.0",
     "sinon": "^1.17.2",
     "sinon-chai": "^2.8.0"
   },
-  "dependencies": {},
+  "dependencies": {
+    "lolex": "^1.5.0"
+  },
   "devDependencies": {}
 }


### PR DESCRIPTION
lolex should not be a peerDependency, it is required to use this library. Users of this library should not be required to install it as a dependency of their projects.